### PR TITLE
Fix  err 400 malformed metadata json

### DIFF
--- a/gphoto_to_immich.py
+++ b/gphoto_to_immich.py
@@ -124,7 +124,7 @@ class ImmichClient:
                 'filename': file_path.name,
                 'deviceAssetId': f"gphoto_1",
                 'deviceId': 'gphoto-migration-tool',
-                'metadata': [{'key': 'mobile-app', 'value': {'source': 'gphoto-import'}}]
+                'metadata': json.dumps([{'key': 'mobile-app', 'value': {'source': 'gphoto-import'}}])
             }
             
             # Add checksum header
@@ -528,14 +528,12 @@ class GooglePhotosProcessor:
     
     def _find_metadata_file(self, file_path: Path) -> Optional[Path]:
         """Find metadata file for a media file"""
-        possible_names = [
-            f"{file_path.name}.supplemental-metadata.json",
-            f"{file_path.name}.supplemental-metadata copy.json"
-        ]
+        pattern = f"*{file_path.name}*.json"
         
-        for name in possible_names:
-            metadata_path = file_path.parent / name
-            if metadata_path.exists():
+        # Iterate over matching files
+        for metadata_path in file_path.parent.glob(pattern):
+            # print(metadata_path)
+            if metadata_path.is_file():
                 return metadata_path
         
         return None

--- a/gphoto_to_immich.py
+++ b/gphoto_to_immich.py
@@ -528,11 +528,8 @@ class GooglePhotosProcessor:
     
     def _find_metadata_file(self, file_path: Path) -> Optional[Path]:
         """Find metadata file for a media file"""
-        pattern = f"*{file_path.name}*.json"
-        
-        # Iterate over matching files
-        for metadata_path in file_path.parent.glob(pattern):
-            # print(metadata_path)
+        metadata_pattern = f"*{file_path.name}*.json"
+        for metadata_path in file_path.parent.glob(metadata_pattern):
             if metadata_path.is_file():
                 return metadata_path
         


### PR DESCRIPTION
This pr proposes a fix for:
- File upload fail with `ERROR 400` complaining `metadata` attribute is "not a valid JSON" (Python dict now explicitly made into a `json.dump`)
- Some metadata JSON files being skipped for having truncated names for unknown reasons (e.g. `.supplemental-metad.json`, metadata is now found with a glob pattern)